### PR TITLE
步驟22: 為使用者加入角色

### DIFF
--- a/app/controllers/admin/backend_controller.rb
+++ b/app/controllers/admin/backend_controller.rb
@@ -1,6 +1,4 @@
-class Admin::BackendController < ApplicationController
-  before_action :require_login
-
+class Admin::BackendController < Admin::BaseController
   def index
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,6 @@
+class Admin::BaseController < ApplicationController
+  include SessionsHelper
+
+  before_action :require_login
+  before_action :authenticate_user!
+end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -24,7 +24,7 @@ class UserController < ApplicationController
     user = User.find_by_email(params[:user][:email])
     if valid_password? && user.authenticate(params[:user][:old_password])
       @user.update(user_params)
-      redirect_to tasks_path, notice: 'User was successfully updated.'
+      redirect_to tasks_path, notice: t('.notice')
     else
       render :edit
     end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,7 +1,19 @@
 module SessionsHelper
+  def authenticate_user!
+    if not admin?
+      return redirect_to (request.referer || root_path), alert: '你不是管理員欸！'
+    end
+  end
+
   def current_user
     return if not session[:user_id]
     @current_user ||= User.find(session[:user_id])
+  end
+
+  def admin?
+    return true if current_user && current_user.role == 'admin'
+
+    return false
   end
 
   def valid_email?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,15 @@
 class User < ApplicationRecord
+  before_destroy :last_user?
+
   has_many :tasks, dependent: :destroy
   
   validates :email, :password_digest, presence: true, uniqueness: true
   validates_format_of :email, :with => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([a-zA-Z]{2,})\z/i
   has_secure_password
+
+  private
+
+  def last_user?
+    throw :abort if User.count < 1
+  end
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,5 +1,23 @@
 <h1><%= I18n.t("users.heading.edit") %></h1>
 
-<%= render 'user/shared/form_edit', user: @user, url: admin_user_path(@user) %>
+<%= form_for(@user, url: admin_user_path(@user)) do |form| %>
+  <div>
+    <%= form.label :email, I18n.t("users.form.email") %>
+    <%= form.text_field :email, readonly: 'readonly' %>
+  </div>
 
-<%= link_to I18n.t("users.back_to_root_path"), root_path, class: 'btn btn-light' %>
+  <div>
+    <%= form.label :role, I18n.t("views.backend.users.form.role.label") %>
+    <%= form.select :role, 
+        options_for_select([
+                            [I18n.t("activerecord.attributes.user.role.admin"), "admin"],
+                            [I18n.t("activerecord.attributes.user.role.user"), "user"]
+                            ], 
+                            @user.role
+                          )
+    %>
+  </div>
+  <%= form.submit I18n.t("views.backend.users.form.submit"), class: 'btn btn-primary' %>
+<% end %>
+
+<%= link_to I18n.t("views.backend.users.back_to_users_index"), admin_users_path, class: 'btn btn-light' %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -16,7 +16,7 @@
     <% @users.each do |user| %>      
       <tr>
         <td class="text-center"><%= user.email %></td>
-        <td class="text-center"><%#= I18n.t("user.table.role.#{user.role}") %></td>
+        <td class="text-center"><%= I18n.t("activerecord.attributes.user.role.#{user.role}") %></td>
         <td class="text-center"><%= link_to "#{I18n.t("views.backend.users.table.task_count")} #{user.tasks_count} #{I18n.t("unit.each")}", admin_user_path(id: user.id) %></td>
         <td class="text-center">
           <%= link_to I18n.t("tasks.table.edit"), edit_admin_user_path(id: user.id) %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -5,10 +5,12 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarText">
     <ul class="navbar-nav mr-auto">
-      <% if current_user %>
+      <% if admin? %>
         <li class="nav-item">
           <%= link_to I18n.t("views.nav.backend"), admin_root_path, class: 'nav-link' %>
         </li>
+      <% end %>
+      <% if current_user %>
         <li class="nav-item">
           <%= link_to I18n.t("views.nav.edit"), edit_user_path(id: current_user.id), class: 'nav-link' %>
         </li>

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -1,4 +1,13 @@
 en:
+  admin:
+    users:
+      create:
+        notice: 'Success: a new user is created!'
+      update:
+        notice: 'Success: the user is updated!'
+      destroy:
+        notice: 'Success: the user is deleted!'
+        alert: 'Failed: unable to delete the user!'
   sessions:
     login: 
       alert: 'You must be logged in to access this section!'
@@ -23,3 +32,5 @@ en:
     create:
       notice: 'Signed up successfully!'
       alert: 'Signed up failed. Please check and enter again!'
+    update:
+      notice: 'Success: the user is updated!'

--- a/config/locales/controllers/zh-TW.yml
+++ b/config/locales/controllers/zh-TW.yml
@@ -1,4 +1,13 @@
 zh-TW:
+  admin:
+    users:
+      create:
+        notice: '使用者新增成功！'
+      update:
+        notice: '使用者更新成功！'
+      destroy:
+        notice: '使用者刪除成功！'
+        alert: '使用者無法刪除！'
   sessions:
     login: 
       alert: '請先登入！'
@@ -23,3 +32,5 @@ zh-TW:
     create:
       notice: '註冊成功！'
       alert: '更新失敗，請檢查輸入資料是否有誤！'
+    update:
+      notice: '使用者更新成功！'

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -23,6 +23,9 @@ en:
         password_digest: 'Password'
         password: 'Password'
         password_confirmation: 'Password confirmation'
+        role:
+          admin: 'Admin'
+          user: 'User'
     errors:
       models:
         task:

--- a/config/locales/models/zh-TW.yml
+++ b/config/locales/models/zh-TW.yml
@@ -23,6 +23,9 @@ zh-TW:
         password_digest: '密碼'
         password: '密碼'
         password_confirmation: '確認密碼'
+        role:
+          admin: '管理員'
+          user: '使用者'
     errors:
       models:
         task:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -93,6 +93,10 @@ en:
           role: 'Role'
           task_count: 'Tasks count'
           edit_user: 'Edit User'
+        form:
+          role:
+            label: 'Role: '
+          submit: 'Submit'
         back_to_users_index: 'Back to User List'
   are_you_sure: 'Are you sure?'
   helpers:

--- a/config/locales/views/zh-TW.yml
+++ b/config/locales/views/zh-TW.yml
@@ -95,6 +95,10 @@ zh-TW:
           role: '角色'
           task_count: '任務數量'
           edit_user: '編輯使用者'
+        form:
+          role:
+            label: '角色：'
+          submit: '送出'
         back_to_users_index: '回到使用者清單'
   are_you_sure: '你確定嗎？'
   helpers:
@@ -120,4 +124,3 @@ zh-TW:
     abbr_month_names: [~, 一月, 二月, 三月, 四月, 五月, 六月, 七月, 八月, 九月, 十月, 十一月, 十二月]
   unit:
     each: '個'
-  

--- a/db/migrate/20190714101055_add_role_to_users.rb
+++ b/db/migrate/20190714101055_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :string, default: 'user'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_14_081131) do
+ActiveRecord::Schema.define(version: 2019_07_14_101055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2019_07_14_081131) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.integer "tasks_count", default: 0
+    t.string "role", default: "user"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
 # 100.times do
 #   FactoryBot.create(:task)
 # end
-User.create(email: 'email@email.com')
+User.where(email: 'email@email.com').first_or_create(password: '111111', role: 'admin').update(password: '111111', role: 'admin')


### PR DESCRIPTION
- 將使用者分為管理員和一般使用者
- 請改成只有管理員可以存取使用者管理頁面
	- 若一般使用者存取管理頁面時，需提示權限不足訊息無法存取，並轉向適當頁面
- 能在使用者管理頁面選擇角色
- 管理者只剩下一個人時，不能再被刪除
	- 利用 model 的 callback 實做